### PR TITLE
Add `curl_info` on recording and playback

### DIFF
--- a/src/VCR/Response.php
+++ b/src/VCR/Response.php
@@ -65,7 +65,8 @@ class Response
             array(
                 'status'    => $this->status,
                 'headers'   => $this->getHeaders(),
-                'body'      => $body
+                'body'      => $body,
+                'curl_info' => $this->curlInfo,
             )
         );
     }
@@ -94,7 +95,8 @@ class Response
         return new static(
             isset($response['status']) ? $response['status'] : 200,
             isset($response['headers']) ? $response['headers'] : array(),
-            $body
+            $body,
+            isset($response['curl_info']) ? $response['curl_info'] : array()
         );
     }
 

--- a/src/VCR/Util/CurlHelper.php
+++ b/src/VCR/Util/CurlHelper.php
@@ -112,7 +112,7 @@ class CurlHelper
                 $info =  mb_strlen(HttpUtil::formatAsStatusWithHeadersString($response), 'ISO-8859-1');
                 break;
             default:
-                $info = $response->getCurlInfo($option);
+                $info = $response->getCurlInfo(self::$curlInfoList[$option]);
                 break;
         }
 

--- a/tests/VCR/ResponseTest.php
+++ b/tests/VCR/ResponseTest.php
@@ -120,6 +120,14 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($curlOptions, $response->getCurlInfo());
     }
 
+    public function testRestoreCurlInfoFromArray()
+    {
+        $expectedCurlOptions = array('option' => 'value');
+        $response = new Response(200, array(), null, $expectedCurlOptions);
+        $restoredResponse = Response::fromArray($response->toArray());
+         $this->assertEquals($expectedCurlOptions, $response->getCurlInfo());
+    }
+
     public function testToArray()
     {
         $expectedArray = array(
@@ -131,7 +139,10 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
             'headers'   => array(
                 'host' => 'example.com'
             ),
-            'body'      => 'Test response'
+            'body'      => 'Test response',
+            'curl_info' => array(
+                'content_type' => 'text/html'
+            )
         );
 
         $response = Response::fromArray($expectedArray);


### PR DESCRIPTION
### Context
This is a bug when curl_info is played back, it returns an array with all null values. This PR fixes that and is a copy of https://github.com/php-vcr/php-vcr/pull/210