### PR TITLE
Return a boolean result from curl_setopt_array

### DIFF
--- a/src/VCR/LibraryHooks/CurlHook.php
+++ b/src/VCR/LibraryHooks/CurlHook.php
@@ -327,13 +327,19 @@ class CurlHook implements LibraryHook
      * @link http://www.php.net/manual/en/function.curl-setopt-array.php
      * @param resource $curlHandle A cURL handle returned by curl_init().
      * @param array    $options    An array specifying which options to set and their values.
+
+     * @return boolean  Returns TRUE on success or FALSE on failure.
      */
     public static function curlSetoptArray($curlHandle, $options)
     {
+        $success = true;
+        
         if (is_array($options)) {
             foreach ($options as $option => $value) {
-                static::curlSetopt($curlHandle, $option, $value);
+                $success = $success && static::curlSetopt($curlHandle, $option, $value);
             }
         }
+
+        return $success;
     }
 }

--- a/tests/VCR/LibraryHooks/CurlHookTest.php
+++ b/tests/VCR/LibraryHooks/CurlHookTest.php
@@ -155,7 +155,7 @@ class CurlHookTest extends \PHPUnit_Framework_TestCase
         );
 
         $curlHandle = curl_init('http://example.com');
-        curl_setopt_array(
+        $success = curl_setopt_array(
             $curlHandle,
             array(
                 CURLOPT_POSTFIELDS => array('para1' => 'val1', 'para2' => 'val2')
@@ -164,6 +164,8 @@ class CurlHookTest extends \PHPUnit_Framework_TestCase
         curl_exec($curlHandle);
         curl_close($curlHandle);
         $this->curlHook->disable();
+
+        $this->assertTrue($success);
     }
 
     public function testShouldReturnCurlInfoStatusCode()


### PR DESCRIPTION
### Context

`curl_setopt_array` is [supposed to return a boolean](https://www.php.net/manual/en/function.curl-setopt-array.php) but the VCR hook doesn't. This breaks code that throws an exception if `curl_setopt_array` does not return true like [the Twilio PHP SDK](https://github.com/twilio/twilio-php/blob/bb26a721b0bb6649c33614244dcd8060e0ccd312/src/Twilio/Http/CurlClient.php#L37).

There's an open PR for this on the php-vcr repo too: https://github.com/php-vcr/php-vcr/pull/271

### What has been done

- return a boolean from the curl_setopt_array hook

### How to test

- run the test suite

### Todo

### Notes


