### PR TITLE
make VCR replay post fields

### DIFF
--- a/src/VCR/Util/HttpClient.php
+++ b/src/VCR/Util/HttpClient.php
@@ -22,8 +22,8 @@ class HttpClient
         $ch = curl_init($request->getUrl());
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $request->getMethod());
         curl_setopt($ch, CURLOPT_HTTPHEADER, HttpUtil::formatHeadersForCurl($request->getHeaders()));
-        if (!is_null($request->getBody())) {
-            curl_setopt($ch, CURLOPT_POSTFIELDS, $request->getBody());
+        if (!is_null($request->getBody()) || !is_null($request->getPostFields())) {
+            curl_setopt($ch, CURLOPT_POSTFIELDS, $request->getBody() ?? $request->getPostFields());
         }
 
         curl_setopt_array($ch, $request->getCurlOptions());


### PR DESCRIPTION
Some libraries are using `CURLOPT_POSTFIELDS` and it sets the `post_fields` (basically using cUrl -F instead of -d https://ec.haxx.se/http/http-postvspost). 

[Example library](https://github.com/facebook/facebook-php-business-sdk/blob/c7bf72b1f5ca8f3fd6120544cb2541546204bf83/src/FacebookAds/Http/Adapter/CurlAdapter.php#L179)

In order to record and replay the post_fields properly, this update is required.