### PR TITLE
Fix faulty request index

### DIFF
--- a/src/VCR/Storage/Yaml.php
+++ b/src/VCR/Storage/Yaml.php
@@ -58,7 +58,7 @@ class Yaml extends AbstractStorage
     public function next()
     {
         $recording = $this->yamlParser->parse($this->readNextRecord());
-        $this->current = $recording[0];
+        $this->current = $recording[0] ?? null;
         ++$this->position;
     }
 

--- a/tests/VCR/CassetteTest.php
+++ b/tests/VCR/CassetteTest.php
@@ -15,10 +15,16 @@ class CassetteTest extends \PHPUnit_Framework_TestCase
      */
     private $cassette;
 
+    /**
+     * @var Storage\Yaml
+     */
+    private $storage;
+
     public function setUp()
     {
         vfsStream::setup('test');
-        $this->cassette = new Cassette('test', new Configuration(), new Storage\Yaml(vfsStream::url('test/'), 'json_test'));
+        $this->storage = new Storage\Yaml(vfsStream::url('test/'), 'json_test');
+        $this->cassette = new Cassette('test', new Configuration(), $this->storage);
     }
 
     public function testInvalidCassetteName()
@@ -40,7 +46,7 @@ class CassetteTest extends \PHPUnit_Framework_TestCase
         $this->cassette->record($request, $response1);
         $this->cassette->record($request, $response2);
 
-        $this->resetIndex();
+        $this->storage->rewind();
 
         $this->assertEquals($response1->toArray(), $this->cassette->playback($request)->toArray());
         $this->assertEquals($response2->toArray(), $this->cassette->playback($request)->toArray());
@@ -52,7 +58,7 @@ class CassetteTest extends \PHPUnit_Framework_TestCase
         $response = new Response(200, array(), 'sometest');
         $this->cassette->record($request, $response);
 
-        $this->resetIndex();
+        $this->storage->rewind();
 
         $this->assertEquals($response->toArray(), $this->cassette->playback($request)->toArray());
     }
@@ -70,13 +76,8 @@ class CassetteTest extends \PHPUnit_Framework_TestCase
         $response = new Response(200, array(), 'sometest');
         $this->cassette->record($request, $response);
 
-        $this->resetIndex();
+        $this->storage->rewind();
 
         $this->assertTrue($this->cassette->hasResponse($request), 'Expected true if request was found.');
-    }
-
-    private function resetIndex()
-    {
-        $this->cassette->resetIndex();
     }
 }


### PR DESCRIPTION
In #2 we merged in a fix that isn't in PHP-VCR to allow us to properly play back recordings when there are multiple identical requests.

The way that fix works is by keeping track of many times a request happens and storing that count as the 'index' on the recording. When playing back recordings we first check if the index matches, and if it does then check if the request matches.

There's a pretty serious bug in the logic though, which prevents the recordings from ever matching correctly. The end result is it's nearly impossible to run VCR in `once` mode and we make tons of HTTP requests we shouldn't make.

When you first create a recording:
- `VideoRecorder` calls `Cassette::playback`, which iterates the index and returns null (index: 0)
- `VideoRecorder` makes the request
- `VideoRecorder` calls `Cassette::record`, which calls `Cassette:hasResponse`, which calls `Cassette::playback`, which iterates the index again (index: 1).
- The recording is saved with index 1

When you go to play back the recording:
- `VideoRecorder` calls `Cassette::playback`, which iterates the index and checks if the recording matches. Because the index is 0 but the cassette was saved with index 1, it doesn't match.
- Since the recording doesn't match VCR makes a new request.

A simple fix for this is to not iterate the index a second time. However the entire index table is unnecessary and we can avoid it entirely.

The Storage class is an Iterator, which has a position. VCR records and plays backs requests sequentially. So what we can do instead is advance the position every time we play a request and never go backwards. If there are two different responses for the same request we know which one to play without checking an index, because we can never play the same recording twice. This avoids the necessity of the index and avoids a lot of unnecessary work checking if recordings match that we already played.
